### PR TITLE
Make franchises optional

### DIFF
--- a/src/components/GameCard.tsx
+++ b/src/components/GameCard.tsx
@@ -48,9 +48,11 @@ export function GameCard(gameCardProps : GameCardProps ) {
                 }))}
             </div>
             <div>
-                {(gameCardProps.gameFranchises.map((franchise) => {
+                { gameCardProps.gameFranchises ?
+                (gameCardProps.gameFranchises.map((franchise) => {
                     return <p>{franchise}</p>
-                }))}
+                }))
+                 : null }
             </div>
             <div>
                 {(gameCardProps.gameCompanies.map((company) => {

--- a/src/interfaces/Game.ts
+++ b/src/interfaces/Game.ts
@@ -3,7 +3,7 @@ export default interface Game {
     name: string 
     platforms: Array<string>
     genres: Array<string>
-    franchises: Array<string>
+    franchises?: Array<string>
     companies: Array<string>
     releaseDate: Array<string>
     summary: string,


### PR DESCRIPTION
## Jira Ticket Number
https://gaming-backlog.atlassian.net/browse/GB-72

## Short description
Makes it so franchise can be nullable. This allows it to not be displayed on the frontend, and to not force franchise to be a required field for certain games that are on their own (e.g. indie games). Examples currently in our DB include Chicory and Live a Live.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Other (please specify)